### PR TITLE
Issue resolved

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/frontend/syntaxmeets/src/components/Home/Home.js
+++ b/frontend/syntaxmeets/src/components/Home/Home.js
@@ -39,6 +39,8 @@ const Home = (props) => {
   const [roomId] = useState(generateRoomId());
   const [joinRoomId, setjoinRoomId] = useState("123");
   const [name, setName] = useState("");
+  const [disabledName, setDisabledName] = useState(true);
+  const [disabledRoomId, setDisabledRoomId] = useState(true);
   
 
   const roomModal = {
@@ -149,6 +151,7 @@ const Home = (props) => {
                         value={name}
                         onChange={(e) => {
                           setName(e.target.value)
+                          e.target.value.length >= 1 ? setDisabledName(false) : setDisabledName(true)
                         }}
                       />
 
@@ -164,6 +167,7 @@ const Home = (props) => {
                           }}
                           variant="contained"
                           size="large"
+                          disabled={disabledName}
                           component={Link}
                           to={{
                             pathname: roomId,
@@ -201,6 +205,7 @@ const Home = (props) => {
                         value={name}
                         onChange={(e) => {
                           setName(e.target.value)
+                          e.target.value.length >= 1 ? setDisabledName(false) : setDisabledName(true)
                         }}
                         style = {{color: '#000'}}
                       />
@@ -216,7 +221,10 @@ const Home = (props) => {
                         Enter Room Id
                       </Typography>
                       <TextField
-                        onChange={(event) => setjoinRoomId(event.target.value)}
+                        onChange={(event) => {
+                          setjoinRoomId(event.target.value)
+                          event.target.value.length >= 14 ? setDisabledRoomId(false) : setDisabledRoomId(true)
+                        }}
                         fullWidth
                         id="outlined-basic"
                         className={classes.root}
@@ -241,6 +249,7 @@ const Home = (props) => {
                           }}
                           variant="contained"
                           size="large"
+                          disabled={disabledName || disabledRoomId}
                           component={Link}
                           to={{
                             pathname: joinRoomId,

--- a/frontend/syntaxmeets/src/components/Home/Home.js
+++ b/frontend/syntaxmeets/src/components/Home/Home.js
@@ -223,7 +223,9 @@ const Home = (props) => {
                       <TextField
                         onChange={(event) => {
                           setjoinRoomId(event.target.value)
-                          event.target.value.length >= 14 ? setDisabledRoomId(false) : setDisabledRoomId(true)
+                          let pattern = new RegExp("(([A-Za-z]{4})(-)){2}[A-Za-z]{4}");
+                          let roomIdStatus = pattern.test(event.target.value);
+                          roomIdStatus ? setDisabledRoomId(false) : setDisabledRoomId(true)
                         }}
                         fullWidth
                         id="outlined-basic"


### PR DESCRIPTION
This PR is realted to issue #48 

There isn't a need to change the UI for alerts. It wasn't the issue related to UI, but for validation.
When I went through the code, the alert which was coming was from different thing i.e the syntaxrooms. 

About the validation, when we hit create room with empty name, it leads to the syntaxRoom and the checking is done over there, whether room id or name is empty or not, which was wrong. I've added the validation on the home page modal itself. As there was no option to stop the redirection on click as we are using MUIButton, so I have used the disability property. I've disabled the buttons till the name or room id is entered or not. Room id validation is till the characters have proper 14 digit code or not. If these are fulfilled, then it allows user to click and enter or join a room. Hence validation is done properly.