### PR TITLE
Long name is now not overflowed

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/frontend/syntaxmeets/src/components/SyntaxChat/ParticipantsList.js
+++ b/frontend/syntaxmeets/src/components/SyntaxChat/ParticipantsList.js
@@ -47,6 +47,10 @@ function ParticipantsList(props) {
                 border: "solid rgb(62 53 53) 1px",
                 textAlign: "center",
                 fontWeight: "bolder",
+                wordWrap: "break-word",
+                overflowWrap: "break-word",
+                hyphens: "auto",
+                WebkitHyphens: "auto",
               }}
               primary={name}
             />


### PR DESCRIPTION
Issue: #106 
Now, the name is not overflowed, it is broken into next line.

Before:
![Screenshot from 2021-04-09 18-58-17](https://user-images.githubusercontent.com/66305085/114188013-48addd80-9966-11eb-982c-be262bb0e5fa.png)


After:
![Screenshot from 2021-04-09 18-57-28](https://user-images.githubusercontent.com/66305085/114187989-421f6600-9966-11eb-878d-2639db9d0d0e.png)
