### PR TITLE
Chatui

### DIFF
--- a/frontend/syntaxmeets/src/components/SyntaxChat/ChatMessage.js
+++ b/frontend/syntaxmeets/src/components/SyntaxChat/ChatMessage.js
@@ -54,7 +54,7 @@ export const ChatMessage = (props) => {
           >
 
             <em>{
-              (localStorage.getItem("my_name") === data.name)? " ": 
+              (localStorage.getItem("my_name") === data.name)? "You": 
             data.name}</em>
           </span>
         }

--- a/frontend/syntaxmeets/src/components/SyntaxChat/ChatMessage.js
+++ b/frontend/syntaxmeets/src/components/SyntaxChat/ChatMessage.js
@@ -52,7 +52,10 @@ export const ChatMessage = (props) => {
               }`,
             }}
           >
-            <em>{data.name}</em>
+
+            <em>{
+              (localStorage.getItem("my_name") === data.name)? " ": 
+            data.name}</em>
           </span>
         }
         secondary={

--- a/frontend/syntaxmeets/src/components/SyntaxChat/SyntaxChat.js
+++ b/frontend/syntaxmeets/src/components/SyntaxChat/SyntaxChat.js
@@ -116,7 +116,15 @@ const SyntaxChat = (props) => {
         Chat Box
       </Button>
       <Drawer anchor={"right"} open={openDrawer} onClose={toggleDrawer(false)}>
-      
+      <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <CloseSharpIcon
+          style={{ padding: "5px", fontSize: "3em", cursor: "pointer" }}
+          onClick={toggleDrawer(false)}
+        />
+        </Grid>
+          </Grid>
+        <Divider/>
        <div
         ref={messagesEndRef}>
         <div
@@ -134,19 +142,7 @@ const SyntaxChat = (props) => {
           >
             {<ChatMessage messages={props.messages} />}
            
-          </div>
-          <div
-          style={{
-            top: "0",
-            position: "fixed",
-            backgroundColor: "#fff"
-          }}>
-          <CloseSharpIcon
-          style={{ padding: "5px", fontSize: "3em", cursor: "pointer" }}
-          onClick={toggleDrawer(false)}
-        />
-        <Divider/>
-          </div>
+          </div>        
           <div
             style={{
               bottom: "0",

--- a/frontend/syntaxmeets/src/components/SyntaxChat/SyntaxChat.js
+++ b/frontend/syntaxmeets/src/components/SyntaxChat/SyntaxChat.js
@@ -66,16 +66,19 @@ const SyntaxChat = (props) => {
   }, []);
 
   const scrollToBottom = () => {
+    
     if (messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+      messagesEndRef.current.scrollIntoView({ behavior: "smooth",block: "end", inline: "nearest" });
     }
   };
+  
 
   function triggerPicker(event) {
     event.preventDefault();
     SetEmojiPicker(!emojiPickerState);
   }
   useEffect(scrollToBottom, [props.messages]);
+ 
   let emojiPicker;
   if (emojiPickerState) {
     emojiPicker = (
@@ -93,6 +96,7 @@ const SyntaxChat = (props) => {
       return;
     }
     setopenDrawer(open);
+   
   };
 
   return (
@@ -112,11 +116,11 @@ const SyntaxChat = (props) => {
         Chat Box
       </Button>
       <Drawer anchor={"right"} open={openDrawer} onClose={toggleDrawer(false)}>
-        <CloseSharpIcon
-          style={{ padding: "5px", fontSize: "3em", cursor: "pointer" }}
-          onClick={toggleDrawer(false)}
-        />
+      
+       <div
+        ref={messagesEndRef}>
         <div
+         
           className={classes.list}
           style={{ display: "flex", flexDirection: "column" }}
           role="presentation"
@@ -129,7 +133,19 @@ const SyntaxChat = (props) => {
             }}
           >
             {<ChatMessage messages={props.messages} />}
-            <div ref={messagesEndRef} />
+           
+          </div>
+          <div
+          style={{
+            top: "0",
+            position: "fixed",
+            backgroundColor: "#fff"
+          }}>
+          <CloseSharpIcon
+          style={{ padding: "5px", fontSize: "3em", cursor: "pointer" }}
+          onClick={toggleDrawer(false)}
+        />
+        <Divider/>
           </div>
           <div
             style={{
@@ -212,7 +228,7 @@ const SyntaxChat = (props) => {
                     }
                   }}
                 />
-                {/* <input
+                {/*<input
                   id="name"
                   class="input-reset ba b--black-20 pa2 mb2 db w-100"
                   type="text"
@@ -247,6 +263,7 @@ const SyntaxChat = (props) => {
               <Grid item xs={1}></Grid>
             </Grid>
           </div>
+        </div>
         </div>
       </Drawer>
     </div>


### PR DESCRIPTION
Made these changes to the SyntaxChat ui.
[Fixes](https://github.com/kothariji/SyntaxMeets/issues/98) 

- Made the Close Icon non-scrollable
- Changed the way ui of message item to resemble how most chat apps have it i.e the current user doesn't see their own name in the message header. 
- I wasn't able to fix opening messages from last unread message. That would require some time-stamps on how messages are stored. Let me know if that's something you'd wish to change.
 

![Screenshot (8)](https://user-images.githubusercontent.com/59924327/118403134-9961d600-b68a-11eb-90be-4d80f3a8983a.png)
 
