### PR TITLE
Copy roomid button text wrapped

### DIFF
--- a/frontend/syntaxmeets/src/components/Navbar/Navbar.js
+++ b/frontend/syntaxmeets/src/components/Navbar/Navbar.js
@@ -89,7 +89,15 @@ const Navbar = (props) => {
               color: "white",
             }}
           >
-            RoomId : {props.roomId}
+            <Typography 
+              style={{
+                  whiteSpace: 'nowrap',
+                  maxWidth: '200px',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis'
+              }}>
+              RoomId : {props.roomId}
+            </Typography>
           </Button>
           <SyntaxChat
             name={props.name}


### PR DESCRIPTION
Closes #142 

Now, if screen size shrinks, the roomId button width doesn't shrinks, but the text is wrapped and ellipsis is added.
![Screenshot from 2021-05-29 22-28-26](https://user-images.githubusercontent.com/66305085/120078642-05522e80-c0ce-11eb-8903-9e01e9e49a39.png)
