### PR TITLE
Room id and alert ellipsis removed and now visible

### DIFF
--- a/frontend/syntaxmeets/src/components/Navbar/Navbar.js
+++ b/frontend/syntaxmeets/src/components/Navbar/Navbar.js
@@ -81,9 +81,7 @@ const Navbar = (props) => {
                   fontFamily: "poppins",
                   fontWeight: "600",
                   color: "white",
-                  maxWidth: '200px',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis'
+                  fontSize: "14px"
               }}>
               RoomId : {props.roomId}
             </Typography>

--- a/frontend/syntaxmeets/src/components/SnackBar/Snackbar.js
+++ b/frontend/syntaxmeets/src/components/SnackBar/Snackbar.js
@@ -13,12 +13,7 @@ class SnackBar extends Component {
             <div>
                 <Snackbar open={this.props.isSnackOpen} autoHideDuration={4000} onClose={() => this.handleClose}>
                     <Alert onClose={() => this.props.close()} severity={this.props.type}>
-                        <Typography 
-                            style={{whiteSpace: 'nowrap',
-                                maxWidth: '200px',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis'
-                            }}>
+                        <Typography>
                             {this.props.snackbarMessage}
                         </Typography>
                     </Alert>


### PR DESCRIPTION
Closes #150 

![Screenshot from 2021-05-31 23-46-19](https://user-images.githubusercontent.com/66305085/120229427-c1e0f700-c26a-11eb-8aaf-82e2d44d0d0c.png)
Room id visible and snackbar ellipsis also removed.